### PR TITLE
Custom day component support

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,12 @@ import { render } from 'react-dom'
 import InfiniteCalendar from './src/index'
 import moment from 'moment'
 
+let selectedDate = false
+const onSelect = (day) => {
+  console.log(day)
+  selectedDate = day
+}
+
 render(<InfiniteCalendar
        min={moment().startOf('month')}
        minDate={moment().startOf('day')}

--- a/index.js
+++ b/index.js
@@ -20,13 +20,12 @@ const style = require('./src/Day/Day.scss');
 const CustomDay = ({currentYear, mmt, yyyymmdd, day, isToday, isDisabled, isSelected, monthShort, locale, theme, customData}) => {
   const className = `${isToday ? style.today : ''} ${isSelected ? style.selected: ''} ${isDisabled ? style.disabled : style.enabled}`
 	var year = mmt.year();
-  const currentData = customData[yyyymmdd]
-  const textColor = currentData ? currentData.color : theme.textColor.default
+  const currentDayData = customData[yyyymmdd]
 
 	return (
       <div className={className} style={(isToday) ? {color: theme.todayColor} : null}>
         {(day === 1) && <span className={style.month}>{monthShort}</span>}
-        <span style={{color: textColor}} >{day}</span>
+        <span style={(currentDayData) && {color: currentDayData.color}} >{day}</span>
         {(day === 1 && currentYear !== year) && <span className={style.year}>{year}</span>}
         {isSelected &&
          <div className={style.selection}

--- a/index.js
+++ b/index.js
@@ -2,7 +2,11 @@ import 'babel-polyfill'
 import React from 'react'
 import { render } from 'react-dom'
 import InfiniteCalendar from './src/index'
+import moment from 'moment'
 
-render(<InfiniteCalendar />,
+render(<InfiniteCalendar
+       min={moment().startOf('month')}
+       minDate={moment().startOf('day')}
+       locale={{week: { dow: 0, doy: 4}}} />,
   document.getElementById('root')
 )

--- a/index.js
+++ b/index.js
@@ -1,18 +1,50 @@
-import 'babel-polyfill'
-import React from 'react'
-import { render } from 'react-dom'
-import InfiniteCalendar from './src/index'
-import moment from 'moment'
+import 'babel-polyfill';
+import React from 'react';
+import { render } from 'react-dom';
+import InfiniteCalendar from './src/index';
+import moment from 'moment';
 
-let selectedDate = false
-const onSelect = (day) => {
-  console.log(day)
-  selectedDate = day
+const data = {
+  '20160612': {
+    color: '#FF007F'
+  },
+  '20160613': {
+    color: '#80FF00'
+  },
+  '20160614': {
+    color: '#BADA55'
+  }
+}
+
+const style = require('./src/Day/Day.scss');
+const CustomDay = ({currentYear, mmt, yyyymmdd, day, isToday, isDisabled, isSelected, monthShort, locale, theme, customData}) => {
+  const className = `${isToday ? style.today : ''} ${isSelected ? style.selected: ''} ${isDisabled ? style.disabled : style.enabled}`
+	var year = mmt.year();
+  const currentData = customData[yyyymmdd]
+  const textColor = currentData ? currentData.color : theme.textColor.default
+
+	return (
+      <div className={className} style={(isToday) ? {color: theme.todayColor} : null}>
+        {(day === 1) && <span className={style.month}>{monthShort}</span>}
+        <span style={{color: textColor}} >{day}</span>
+        {(day === 1 && currentYear !== year) && <span className={style.year}>{year}</span>}
+        {isSelected &&
+         <div className={style.selection}
+           style={{backgroundColor: (typeof theme.selectionColor == 'function') ? theme.selectionColor(mmt) : theme.selectionColor, color: theme.textColor.active}}>
+           <span className={style.month}>{(isToday) ? (locale.todayLabel.short || locale.todayLabel.long) : monthShort}</span>
+           <span className={style.day}>{day}</span>
+         </div>
+		    }
+      </div>
+	);
 }
 
 render(<InfiniteCalendar
-       min={moment().startOf('month')}
-       minDate={moment().startOf('day')}
-       locale={{week: { dow: 0, doy: 4}}} />,
+         min={moment().startOf('month')}
+         minDate={moment().startOf('day')}
+         locale={{week: { dow: 0, doy: 4}}}
+         DayComponent={CustomDay}
+         customData={data}
+       />,
   document.getElementById('root')
 )

--- a/src/Day/Day.scss
+++ b/src/Day/Day.scss
@@ -25,7 +25,7 @@
     cursor: pointer;
     user-select: none;
 
-    &.enabled {
+    > div.enabled {
         &.highlighted, &:active, &:hover {
             position: relative;
             z-index: 1;
@@ -50,11 +50,11 @@
         position: relative;
     }
 
-    &.today {
+    > div.today {
         position: relative;
         z-index: 2;
 
-        > span {
+        >  span {
             color: $textColor;
         }
 
@@ -72,7 +72,8 @@
             box-shadow: inset 0 0 0 1px #BBB;
         }
     }
-    &.selected {
+
+    > div.selected {
         position: relative;
 
         > .month, > .year {
@@ -100,7 +101,7 @@
             }
         }
     }
-    &.disabled {
+    > div.disabled {
         cursor: default;
         color: #AAA;
         cursor: not-allowed;

--- a/src/Day/index.js
+++ b/src/Day/index.js
@@ -1,17 +1,24 @@
 import React from 'react';
 const style = require('./Day.scss');
 
-export default function Day({currentYear, date, day, handleDayClick, isDisabled, isToday, isSelected, monthShort, locale, theme}) {
-	var {date: mmt, yyyymmdd} = date;
+// todo add hover event
+export const withEvents = Component => ({date : {date: mmt, yyyymmdd}, isDisabled, handleDayClick, ...other}) => (
+    <li className={style.root}
+      onClick={isDisabled ? null : handleDayClick.bind(this, mmt)}
+      data-date={yyyymmdd} >
+      <Component
+        {...other}
+        mmt={mmt}
+        yyyymmdd={yyyymmdd}
+        isDisabled={isDisabled} />
+    </li>);
+
+export const DefaultDay = ({currentYear, mmt, yyyymmdd, day, isToday, isDisabled, isSelected, monthShort, locale, theme}) => {
+  const className = `${isToday ? style.today : ''} ${isSelected ? style.selected: ''} ${isDisabled ? style.disabled : style.enabled}`
 	var year = mmt.year();
 
 	return (
-		<li
-			style={(isToday) ? {color: theme.todayColor} : null}
-			className={`${style.root}${isToday ? ' ' + style.today : ''}${isSelected ? ' ' + style.selected : ''}${isDisabled ? ' ' + style.disabled : ' ' + style.enabled}`}
-			data-date={yyyymmdd}
-			onClick={(!isDisabled && handleDayClick) ? handleDayClick.bind(this, mmt) : null}
-		>
+    <div className={className} style={(isToday) ? {color: theme.todayColor} : null}>
 			{(day === 1) && <span className={style.month}>{monthShort}</span>}
 			<span>{day}</span>
 			{(day === 1 && currentYear !== year) && <span className={style.year}>{year}</span>}
@@ -21,6 +28,6 @@ export default function Day({currentYear, date, day, handleDayClick, isDisabled,
 					<span className={style.day}>{day}</span>
 				</div>
 			}
-		</li>
+    </div>
 	);
 }

--- a/src/Day/index.js
+++ b/src/Day/index.js
@@ -4,7 +4,7 @@ const style = require('./Day.scss');
 // todo add hover event
 export const withEvents = Component => ({date : {date: mmt, yyyymmdd}, isDisabled, handleDayClick, ...other}) => (
     <li className={style.root}
-      onClick={isDisabled ? null : handleDayClick.bind(this, mmt)}
+      onClick={(isDisabled || !handleDayClick) ? null : handleDayClick.bind(this, mmt)}
       data-date={yyyymmdd} >
       <Component
         {...other}
@@ -18,7 +18,7 @@ export const DefaultDay = ({currentYear, mmt, yyyymmdd, day, isToday, isDisabled
 	var year = mmt.year();
 
 	return (
-    <div className={className} style={(isToday) ? {color: theme.todayColor} : null}>
+    <div data-date={yyyymmdd} className={className} style={(isToday) ? {color: theme.todayColor} : null}>
 			{(day === 1) && <span className={style.month}>{monthShort}</span>}
 			<span>{day}</span>
 			{(day === 1 && currentYear !== year) && <span className={style.year}>{year}</span>}
@@ -31,3 +31,5 @@ export const DefaultDay = ({currentYear, mmt, yyyymmdd, day, isToday, isDisabled
     </div>
 	);
 }
+
+export default withEvents(DefaultDay)

--- a/src/List/index.js
+++ b/src/List/index.js
@@ -81,11 +81,12 @@ export default class List extends Component {
 		}
 	};
 	renderMonth = ({index, isScrolling}) => {
-		let {disabledDates, disabledDays, locale, months, maxDate, minDate, onDaySelect, rowHeight, selectedDate, showOverlay, theme, today} = this.props;
+		let {disabledDates, disabledDays, locale, months, maxDate, minDate, onDaySelect, rowHeight, selectedDate, showOverlay, theme, today, ...other} = this.props;
 		let {date, rows} = this.memoize(months[index]);
 
 		return (
 			<Month
+        {...other}
 				key={`Month-${index}`}
 				selectedDate={selectedDate}
 				displayDate={date}
@@ -100,10 +101,11 @@ export default class List extends Component {
 				showOverlay={showOverlay}
 				today={today}
 				theme={theme}
-				locale={locale}
+        locale={locale}
 			/>
 		);
 	};
+
 	render() {
 		let {height, isScrolling, onScroll, overscanMonthCount, months, rowHeight, selectedDate, today, width} = this.props;
 		if (!this.initScrollTop) this.initScrollTop = this.getDateOffset(selectedDate && selectedDate.date || today.date);

--- a/src/Month/index.js
+++ b/src/Month/index.js
@@ -19,6 +19,7 @@ export default class Month extends Component {
 		let row, date, days;
     let Day = DayComponent || DefaultDay
     Day = withEvents(Day)
+    Day.displayName = 'Day'
 
 		// Oh the things we do in the name of performance...
 		for (let i = 0, len = rows.length; i < len; i++) {

--- a/src/Month/index.js
+++ b/src/Month/index.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import classNames from 'classnames';
-import Day from '../Day';
+import {withEvents, DefaultDay} from '../Day';
 const style = require('./Month.scss');
 
 export default class Month extends Component {
@@ -8,7 +8,7 @@ export default class Month extends Component {
 		return (!nextProps.isScrolling && !this.props.isScrolling);
 	}
 	renderRows() {
-		let {disabledDates, disabledDays, displayDate, locale, maxDate, minDate, onDaySelect, rowHeight, rows, selectedDate, today, theme} = this.props;
+		let {disabledDates, disabledDays, displayDate, locale, maxDate, minDate, onDaySelect, rowHeight, rows, selectedDate, today, theme, DayComponent, ...other} = this.props;
 		let currentYear = today.date.year();
 		let monthShort = displayDate.format('MMM');
 		let monthRows = [];
@@ -17,6 +17,8 @@ export default class Month extends Component {
 		let isSelected = false;
 		let isToday = false;
 		let row, date, days;
+    let Day = DayComponent || DefaultDay
+    Day = withEvents(Day)
 
 		// Oh the things we do in the name of performance...
 		for (let i = 0, len = rows.length; i < len; i++) {
@@ -38,6 +40,7 @@ export default class Month extends Component {
 
 				days[k] = (
 					<Day
+            {...other}
 						key={`day-${day}`}
 						currentYear={currentYear}
 						date={date}
@@ -48,7 +51,7 @@ export default class Month extends Component {
 						isSelected={isSelected}
 						locale={locale}
 						monthShort={monthShort}
-						theme={theme}
+            theme={theme}
 					/>
 				);
 			}

--- a/src/utils.js
+++ b/src/utils.js
@@ -69,8 +69,8 @@ export function getMonth(monthDate) {
 export function getWeeksInMonth(date, locale) {
 	let first = moment(date).startOf('month');
 	let last = moment(date).endOf('month');
-	let firstWeek = first.week();
-	let lastWeek = last.week();
+	let firstWeek = locale.week.dow === 1 ? first.isoWeek() : first.week();
+	let lastWeek =  locale.week.dow === 1 ? last.isoWeek() : last.week();
 
 	// For those tricky months...
 	//
@@ -92,7 +92,7 @@ export function getWeeksInMonth(date, locale) {
 	let rows = lastWeek - firstWeek;
 
 	// If the last week contains 7 days, we need to add an extra row
-	if (last.clone().subtract(6,'day').day() == locale.week.dow) {
+  if (last.clone().subtract(6,'day').day() == locale.week.dow) {
 		rows++;
 	}
 

--- a/test/Calendar.test.js
+++ b/test/Calendar.test.js
@@ -7,7 +7,6 @@ import sinon from 'sinon';
 import moment from 'moment';
 import {keyCodes} from '../src/utils';
 import InfiniteCalendar from '../src/';
-import Day from '../src/Day';
 
 const style = {
 	day: require('../src/Day/Day.scss'),
@@ -158,7 +157,7 @@ describe("<InfiniteCalendar/> Callback Events", function() {
 	it('should fire a callback beforeSelect', (done) => {
 		const beforeSelect = sinon.spy();
 		const wrapper = mount(<InfiniteCalendar beforeSelect={beforeSelect} />);
-		wrapper.find(Day).first().simulate('click');
+		wrapper.find('Day').first().simulate('click');
 
 		expect(beforeSelect.calledOnce).to.equal(true);
 		setTimeout(done);
@@ -166,7 +165,7 @@ describe("<InfiniteCalendar/> Callback Events", function() {
 	it('should fire a callback onSelect', (done) => {
 		const onSelect = sinon.spy();
 		const wrapper = mount(<InfiniteCalendar onSelect={onSelect} />);
-		wrapper.find(Day).first().simulate('click');
+		wrapper.find('Day').first().simulate('click');
 
 		expect(onSelect.calledOnce).to.equal(true);
 		setTimeout(done);
@@ -174,7 +173,7 @@ describe("<InfiniteCalendar/> Callback Events", function() {
 	it('should fire a callback afterSelect', (done) => {
 		const afterSelect = sinon.spy();
 		const wrapper = mount(<InfiniteCalendar afterSelect={afterSelect} />);
-		wrapper.find(Day).first().simulate('click');
+		wrapper.find('Day').first().simulate('click');
 
 		expect(afterSelect.calledOnce).to.equal(true);
 		setTimeout(done);
@@ -188,7 +187,7 @@ describe("<InfiniteCalendar/> Callback Events", function() {
 		const afterSelect = sinon.spy();
 		const wrapper = mount(<InfiniteCalendar selectedDate={expected} beforeSelect={beforeSelect} onSelect={onSelect} afterSelect={afterSelect} />);
 
-		wrapper.find(Day).first().simulate('click');
+		wrapper.find('Day').first().simulate('click');
 
 		expect(onSelect.called).to.equal(false);
 		expect(afterSelect.called).to.equal(false);

--- a/test/Day.test.js
+++ b/test/Day.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import chai, {expect} from 'chai';
 import chaiEnzyme from 'chai-enzyme';
-import { mount, shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 import moment from 'moment';
 import defaultTheme from '../src/theme';
@@ -50,7 +50,7 @@ describe("<Day/>", () => {
         const wrapper = mount(
 			<Day
 				currentYear={2016}
-				date={{date, yyyymmdd: date.format('YYYYMMDD')}}
+        date={{date, yyyymmdd: date.format('YYYYMMDD')}}
 				day={8}
 				isSelected={true}
 				locale={defaultLocale}
@@ -61,16 +61,18 @@ describe("<Day/>", () => {
 					}
 				}}
 			/>
-		);
-		expect(wrapper.find(`.${style.selection}`)).to.have.style('background-color', 'red');
-		expect(wrapper.find(`.${style.selection}`)).to.have.style('color', 'blue');
+        );
+
+    const element = wrapper.find(`.${style.root}`).find(`.${style.selection}`)
+		expect(element).to.have.style('background-color', 'red');
+		expect(element).to.have.style('color', 'blue');
 	})
 	it('supports dynamically setting the selection color with a function', () => {
 		const date = moment('20160308', 'YYYYMMDD');
         const wrapper = mount(
 			<Day
 				currentYear={2016}
-				date={{date, yyyymmdd: date.format('YYYYMMDD')}}
+        date={{date, yyyymmdd: date.format('YYYYMMDD')}}
 				day={8}
 				isSelected={true}
 				locale={defaultLocale}
@@ -82,6 +84,6 @@ describe("<Day/>", () => {
 				}}
 			/>
 		);
-		expect(wrapper.find(`.${style.selection}`)).to.have.style('background-color', 'orange');
+		expect(wrapper.find(`.${style.root}`).find(`.${style.selection}`)).to.have.style('background-color', 'orange');
 	})
 });

--- a/test/Month.test.js
+++ b/test/Month.test.js
@@ -5,7 +5,6 @@ import { shallow } from 'enzyme';
 import moment from 'moment';
 import {getMonth, parseDate} from '../src/utils';
 import Month from '../src/Month';
-import Day from '../src/Day';
 
 chai.use(chaiEnzyme());
 
@@ -23,6 +22,6 @@ describe("<Month/>", () => {
 				today={today}
 			/>
 		);
-		expect(wrapper.find(Day)).to.have.length(moment().daysInMonth());
+		expect(wrapper.find('Day')).to.have.length(moment().daysInMonth());
 	})
 });


### PR DESCRIPTION
implementation of custom day component.

User can specify custom day component, by setting DayComponend property. 
This component will be rendered inside of li element in calendar.
DayComponent is just for displaying data, mouseClicks are still provided by beforeSelect, onSelect, afterSelect events, specified on li component.

Styles for today, selected, disabled, enabled are responsibility of DayComponent.

All Props are being passed all the way down to DayComponent, so you user can pass specific data to DayComponent.