### PR TITLE
Allow forks of this project to be able to npm install from git+https or git+ssh

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,5 @@
 .github
-.babelrc
 coverage
-src
 test
 .*
 *.md
@@ -9,7 +7,5 @@ server.js
 index.html
 /index.js
 karma.conf.js
-webpack.config.*.js
-babel.preprocess.sass.js
 codecov.yml
 .travis.yml

--- a/bin/postinstall
+++ b/bin/postinstall
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+node -e "require('fs').stat('dist', function (e, s) { process.exit(e || !s.isDirectory() ? 1 : 0) })" || npm install --ignore-scripts --only=dev && npm run build
+

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "clean:es6": "rimraf dist/es6",
     "clean:commonjs": "rimraf dist/commonjs",
     "test": "cross-env BABEL_ENV=testing karma start --single-run --browsers PhantomJS",
-    "codecov": "cat coverage/*/lcov.info | codecov"
+    "codecov": "cat coverage/*/lcov.info | codecov",
+    "postinstall": "./bin/postinstall"
   },
   "dependencies": {
     "classnames": "^2.1.2",
@@ -75,6 +76,7 @@
     "babel-loader": "^6.2.0",
     "babel-plugin-css-modules-transform": "^0.1.0",
     "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-es2015-rollup": "^1.1.1",
@@ -93,7 +95,7 @@
     "enzyme": "^2.3.0",
     "eslint": "^2.10.1",
     "eslint-config-xo-react": "^0.7.0",
-    "eslint-plugin-react": "^5.1.1",
+    "eslint-plugin-react": "^6.2.0",
     "expect": "^1.8.0",
     "express": "^4.13.3",
     "extract-text-webpack-plugin": "^1.0.1",


### PR DESCRIPTION
I believe this would do the trick.

Essentially:

```
run postinstall
- if dist/ folder doesn't exist (then you didn't get this package from npm registry)
- - then run an npm install for only devDependencies because initial npm install ignores devDependencies, ignoring npm scripts so that postinstall won't occur again and again recursively
```

The only problem now is the relative paths in the .babelrc for preProcess, for example, cause this error:

`Error: src/Day/index.js: Module 'my-project/node_modules/react-infinite-calendar/babel.preprocess.sass.js' does not exist or is not a function.`

Not sure why the error is reported from src/Day/index.js, it really just has to do with the relative path in babelrc and how that gets utilized.

Any thoughts?
