### PR TITLE
Allow percentage based widths

### DIFF
--- a/src/Calendar/index.js
+++ b/src/Calendar/index.js
@@ -107,7 +107,7 @@ export default class Calendar extends Component {
       todayColor: PropTypes.string,
       weekdayColor: PropTypes.string,
     }),
-    width: PropTypes.number,
+    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     YearsComponent: PropTypes.func,
   };
   componentDidMount() {


### PR DESCRIPTION
This allows the component's width to be specified with a percentage width instead of numerical pixels.