### PR TITLE
Fix the headerFormat locale for range calendar

### DIFF
--- a/src/Header/withRange.js
+++ b/src/Header/withRange.js
@@ -12,7 +12,7 @@ export default withImmutableProps(({renderSelection}) => ({
       return defaultSelectionRenderer(values.start, props);
     }
 
-    const dateFormat = props.locale && props.locale.headerFormat ? props.locale.headerFormat : 'MMM Do';
+    const dateFormat = props.locale && props.locale.headerFormat || 'MMM Do';
 
     return (
       <div className={styles.range} style={{color: props.theme.headerColor}}>

--- a/src/Header/withRange.js
+++ b/src/Header/withRange.js
@@ -12,7 +12,7 @@ export default withImmutableProps(({renderSelection}) => ({
       return defaultSelectionRenderer(values.start, props);
     }
 
-    const dateFormat = 'MMM Do';
+    const dateFormat = props.locale && props.locale.headerFormat ? props.locale.headerFormat : 'MMM Do';
 
     return (
       <div className={styles.range} style={{color: props.theme.headerColor}}>


### PR DESCRIPTION
Managed to quickly fix the problem with this code, although I don't know if there's a better way of doing it. 

closes #93 

EDIT:
I think you're missing `webpack` in your `package.json` because I couldn't make `npm start` to work before I ran `npm install webpack`.