### PR TITLE
Added displayOptions prop to show or hide Weekdays

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ For more usage examples, see [http://clauderic.github.io/react-infinite-calendar
 | shouldHeaderAnimate  | Boolean | `true`       | Enable/Disable the header animation                                                                                                              |
 | showOverlay          | Boolean | `true`       | Show/hide the month overlay when scrolling                                                                                                       |
 | showTodayHelper      | Boolean | `true`       | Show/hide the floating back to `Today` helper                                                                                                    |
+| showWeekdays         | Boolean | `true`       | Show/hide the weekdays in the header                                                                                                             |
 | hideYearsOnSelect    | Boolean | `true`       | Whether to automatically hide the `years` view on select.                                                                                        |
 | overscanMonthCount   | Number  | `4`          | Number of months to render above/below the visible months. Tweaking this can help reduce flickering during scrolling on certain browers/devices. |
 | todayHelperRowOffset | Number  | `4`          | This controls the number of rows to scroll past before the *Today* helper appears                                                                |

--- a/src/.stories/index.js
+++ b/src/.stories/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable sort-keys */
-import React, {Component} from 'react';
+import React from 'react';
 import {addDecorator, storiesOf} from '@kadira/storybook';
 import InfiniteCalendar, {
   Calendar,
@@ -181,6 +181,13 @@ storiesOf('Display Options', module)
       display={'years'}
       displayOptions={{
         showMonthsForYears: false,
+      }}
+    />
+  ))
+  .add('Hide Weekdays Helper', () => (
+    <InfiniteCalendar
+      displayOptions={{
+        showWeekdays: false,
       }}
     />
   ));

--- a/src/Calendar/index.js
+++ b/src/Calendar/index.js
@@ -70,6 +70,7 @@ export default class Calendar extends Component {
       showMonthsForYears: PropTypes.bool,
   		showOverlay: PropTypes.bool,
   		showTodayHelper: PropTypes.bool,
+  		showWeekdays: PropTypes.bool,
       todayHelperRowOffset: PropTypes.number,
     }),
     height: PropTypes.number,
@@ -288,6 +289,7 @@ export default class Calendar extends Component {
       showMonthsForYears,
       showOverlay,
       showTodayHelper,
+      showWeekdays,
     } = this.getDisplayOptions();
     const {display, isScrolling, showToday} = this.state;
     const disabledDates = this.getDisabledDates(this.props.disabledDates);
@@ -324,7 +326,9 @@ export default class Calendar extends Component {
           />
         }
         <div className={styles.container.wrapper}>
-          <Weekdays weekdays={locale.weekdays} weekStartsOn={locale.weekStartsOn} theme={theme} />
+          {showWeekdays &&
+            <Weekdays weekdays={locale.weekdays} weekStartsOn={locale.weekStartsOn} theme={theme} />
+          }
           <div className={styles.container.listWrapper}>
             {showTodayHelper &&
               <Today

--- a/src/utils/defaultDisplayOptions.js
+++ b/src/utils/defaultDisplayOptions.js
@@ -7,5 +7,6 @@ module.exports = {
   showMonthsForYears: true,
   showOverlay: true,
   showTodayHelper: true,
+  showWeekdays: true,
   todayHelperRowOffset: 4,
 };


### PR DESCRIPTION
Based on our designer's feedback at MLS, I added a property to the displayOptions object to show/hide the Weekdays component. I also added an example to the storybook to illustrate the new feature. 😀 