### PR TITLE
Fix getWeek for DST changes aka month overlapping

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -62,7 +62,7 @@ export function getWeek(yearStart, date, weekStartsOn) {
     : yearStart;
 
   return Math.ceil(
-    ((date - yearStartDate) / (60 * 60 * 24 * 1000) + yearStartDate.getDay() + 1 - weekStartsOn) / 7
+    (Math.round((date - yearStartDate) / (60 * 60 * 24 * 1000)) + yearStartDate.getDay() + 1 - weekStartsOn) / 7
   );
 }
 


### PR DESCRIPTION
A forward DST change produces a decimal value for the "days since
start of year" part of the calculation, which depending on the value of
"first day of week" might throw the calculation off. This fix rounds off
the decimal. Using round because rounding to the closest full day should
fix it in all cases as all DST changes are up to only 1 hour.

The problem can be reproduced by setting the timezone to Sao Paulo or Melbourne (among others).

EDIT: oh and the first-day-of-week setting is also important when reproducing. For Sao Paulo for example `weekStartsOn` has to be `0` (sunday). That makes the end of April 2017 overlap with May.

closes #97