### PR TITLE
Update styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -282,10 +282,8 @@
     .Cal__Today__root.Cal__Today__show .Cal__Today__chevron {
       transition: transform 0.3s ease; }
   .Cal__Today__root .Cal__Today__chevron {
-    position: absolute;
-    top: 50%;
-    margin-top: -6px;
-    margin-left: 5px;
+    position: relative;
+    margin-left: 10px;
     transform: rotate(270deg);
     transition: transform 0.3s ease; }
   .Cal__Today__root.Cal__Today__chevronUp .Cal__Today__chevron {


### PR DESCRIPTION

![capture](https://cloud.githubusercontent.com/assets/8875724/26014686/fb00f7fc-375d-11e7-93da-90c971612824.PNG)
Floating today helper chevron was not correctly placed on firefox browser.  Code fix resolves the issue.