### PR TITLE
Update styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -114,6 +114,12 @@
   border-top-left-radius: 50%;
   border-bottom-left-radius: 50%; }
 
+.Cal__Month__row.Cal__Month__partial:first-child li:first-child.Cal__Day__range div.Cal__Day__selection {
+    border-left: 1px solid #448AFF; }
+
+.Cal__Month__row.Cal__Month__partial:first-child li:first-child.Cal__Day__range.Cal__Day__selected.Cal__Day__end::after {
+    border-left: 1px solid #448AFF; }
+
 .Cal__Day__range.Cal__Day__selected.Cal__Day__start:after {
   right: 0; }
 


### PR DESCRIPTION

![capture](https://cloud.githubusercontent.com/assets/8875724/26017901/38589534-376c-11e7-96ef-1f70a4dd496a.PNG)
When range is used, code change adds divider between months within the select range.  The border-left color is set explicit in the css.  I think this should be somewhere else, so, maybe keep the result as an idea.