### PR TITLE
remove unused string refs

### DIFF
--- a/src/Today/index.js
+++ b/src/Today/index.js
@@ -35,7 +35,6 @@ export default class Today extends PureComponent {
           color: theme.floatingNav.color,
         }}
         onClick={this.scrollToToday}
-        ref="node"
       >
         {todayLabel}
         <svg

--- a/src/Years/index.js
+++ b/src/Years/index.js
@@ -119,7 +119,6 @@ export default class Years extends Component {
         style={{color: theme.selectionColor, height: height + 50}}
       >
         <VirtualList
-          ref="List"
           className={styles.list}
           width={width}
           height={containerHeight}


### PR DESCRIPTION
throws errors on react 16.7 (possibly other versions as well)