### PR TITLE
filterDate prop for generic date filtering

### DIFF
--- a/src/.stories/index.js
+++ b/src/.stories/index.js
@@ -48,6 +48,12 @@ storiesOf('Basic settings', module)
       )}
     />
   ))
+  .add('Filter Dates', () => (
+    <InfiniteCalendar
+      selected={today}
+      filterDate={date => [format(today, 'YYYY-MM-DD'), format(addDays(today, 3), 'YYYY-MM-DD')].indexOf(format(date, 'YYYY-MM-DD')) !== -1} // Custom date filtering
+    />
+  ))
   .add('Disable Specific Weekdays', () => (
     <InfiniteCalendar disabledDays={[0, 6]} />
   ));

--- a/src/Calendar/index.js
+++ b/src/Calendar/index.js
@@ -60,6 +60,7 @@ export default class Calendar extends Component {
     DayComponent: PropTypes.func,
     disabledDates: PropTypes.arrayOf(PropTypes.instanceOf(Date)),
     disabledDays: PropTypes.arrayOf(PropTypes.number),
+    filterDate: PropTypes.func,
     display: PropTypes.oneOf(['years', 'days']),
     displayOptions: PropTypes.shape({
       hideYearsOnSelect: PropTypes.bool,
@@ -271,6 +272,7 @@ export default class Calendar extends Component {
       DayComponent,
 			disabledDays,
       displayDate,
+      filterDate,
 			height,
       HeaderComponent,
       rowHeight,
@@ -346,6 +348,7 @@ export default class Calendar extends Component {
               DayComponent={DayComponent}
               disabledDates={disabledDates}
               disabledDays={disabledDays}
+              filterDate={filterDate}
               height={height}
               isScrolling={isScrolling}
               locale={locale}

--- a/src/Month/index.js
+++ b/src/Month/index.js
@@ -12,6 +12,7 @@ export default class Month extends PureComponent {
       DayComponent,
       disabledDates,
       disabledDays,
+      filterDate,
       monthDate,
       locale,
       maxDate,
@@ -54,7 +55,8 @@ export default class Month extends PureComponent {
 					minDate && date < _minDate ||
 					maxDate && date > _maxDate ||
 					disabledDays && disabledDays.length && disabledDays.indexOf(dow) !== -1 ||
-					disabledDates && disabledDates.length && disabledDates.indexOf(date) !== -1
+          disabledDates && disabledDates.length && disabledDates.indexOf(date) !== -1 ||
+          filterDate && !filterDate(date)
 				);
 
         days[k] = (

--- a/src/MonthList/index.js
+++ b/src/MonthList/index.js
@@ -20,6 +20,7 @@ export default class MonthList extends Component {
   static propTypes = {
     disabledDates: PropTypes.arrayOf(PropTypes.string),
     disabledDays: PropTypes.arrayOf(PropTypes.number),
+    filterDate: PropTypes.func,
     height: PropTypes.number,
     isScrolling: PropTypes.bool,
     locale: PropTypes.object,
@@ -121,6 +122,7 @@ export default class MonthList extends Component {
       DayComponent,
       disabledDates,
       disabledDays,
+      filterDate,
       locale,
       maxDate,
       minDate,
@@ -145,6 +147,7 @@ export default class MonthList extends Component {
         monthDate={date}
         disabledDates={disabledDates}
         disabledDays={disabledDays}
+        filterDate={filterDate}
         maxDate={maxDate}
         minDate={minDate}
         rows={rows}


### PR DESCRIPTION
Filter date property will get possibility to enable specific dates in the calendar based on external condition.
This is needed, for example, when calendar displays dates, which have some date. In this case the list of disabled date can be huge and it is handy to invert it. Generic function allows to implement all this cases.

Related issue: #45 