### PR TITLE
(fix) call onSelect with interpolated data

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,10 +29,11 @@ export default class DefaultCalendar extends Component {
   }
   handleSelect = (selected) => {
     const {onSelect, interpolateSelection} = this.props;
+    const interpolatedSelection = interpolateSelection(selected, this.state.selected);
 
-    if (typeof onSelect === 'function') { onSelect(selected); }
+    if (typeof onSelect === 'function') { onSelect(interpolatedSelection); }
 
-    this.setState({selected: interpolateSelection(selected, this.state.selected)});
+    this.setState({selected: interpolatedSelection});
   }
   render() {
     // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
This should fix https://github.com/clauderic/react-infinite-calendar/issues/221

I am trying to use this library with [multi selection on](http://clauderic.github.io/react-infinite-calendar/#/enhance-default-functionality/multiple-date-selection?_k=6jfit5).

Problem is that `onSelect` is called with a single value not the whole array. The reason is because interpolate function is used to update internal state but not for calling `onSelect`.

I believe this should fix the issue but I am new to this library so I would like to ask for a deeper code review. Thank you.